### PR TITLE
pin solc version to 08.25 to fix verification

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -16,7 +16,8 @@ remappings = [
 ]
 test = 'test'
 cache_path  = 'cache_forge'
-solc_version = '0.8.22'
+solc_version = '0.8.25'
+optimizer = true
 optimizer_runs = 2000
 fs_permissions = [{ access = "read", path = "node_modules/@arbitrum/"}, { access = "read", path = "node_modules/@openzeppelin/"},{ access = "read-write", path = "./scripts/foundry"}]
 script = 'scripts'

--- a/migration/README.md
+++ b/migration/README.md
@@ -101,7 +101,7 @@ Between the first and second deployment, you need to record the address of the n
 #### DeployAndInitEspressoSequencerInbox.s.sol
 
 ```
-forge script --chain $PARENT_CHAIN_CHAIN_ID contracts/parent-chain/espresso-migration/DeployAndInitEspressoSequencerInbox.s.sol:DeployAndInitEspressoSequencerInbox --rpc-url $PARENT_CHAIN_RPC_URL --broadcast -vvvv --skip-simulation
+forge script --chain $PARENT_CHAIN_CHAIN_ID contracts/parent-chain/espresso-migration/DeployAndInitEspressoSequencerInbox.s.sol:DeployAndInitEspressoSequencerInbox --rpc-url $PARENT_CHAIN_RPC_URL --broadcast -vvvv --verify --skip-simulation --etherscan-api-key YOUR_ETHERSCAN_KEY
 ```
 
 In a similar manner, you will need to record the sequencer inbox address in the env var `NEW_SEQUENCER_INBOX_IMPL_ADDRESS` after the second step during the migration.
@@ -115,7 +115,7 @@ cat broadcast/DeployAndInitEspressoSequencerInbox.s.sol/$PARENT_CHAIN_ID/run-lat
 #### DeployEspressoSequencerMigrationAction.s.sol
 
 ```
-forge script --chain $PARENT_CHAIN_CHAIN_ID contracts/parent-chain/espresso-migration/DeployEspressoSequencerMigrationAction.s.sol:DeployEspressoSequencerMigrationAction --rpc-url $PARENT_CHAIN_RPC_URL --broadcast -vvvv --skip-simulation
+forge script --chain $PARENT_CHAIN_CHAIN_ID contracts/parent-chain/espresso-migration/DeployEspressoSequencerMigrationAction.s.sol:DeployEspressoSequencerMigrationAction --rpc-url $PARENT_CHAIN_RPC_URL --broadcast -vvvv --verify --skip-simulation --etherscan-api-key YOUR_ETHERSCAN_KEY
 
 ```
 


### PR DESCRIPTION
### This PR:
Pins the orbit actions foundry version to 08.25 to make contract verification during deployment more reliable.
