### PR TITLE
Update Nitro Contracts Version to Latest (AWS Nitro)

### DIFF
--- a/migration/espresso-2.1.3/info.md
+++ b/migration/espresso-2.1.3/info.md
@@ -2,5 +2,5 @@
 
 The hardhat artifacts were generated using the following commits:
 
-- nitro-contracts: 26ce69b21816956bb63c9fce36ed404c12d436a1
+- nitro-contracts: 8e58a9e2612f2819a9060d99ca1fb33de4b1414b
    - espresso-tee-contracts: 080c31ed8fa63f6a489cce74a139620fa8b5794b


### PR DESCRIPTION
This pull request updates the commit reference for the `nitro-contracts` repository in the migration documentation.

* [`migration/espresso-2.1.3/info.md`](diffhunk://#diff-51e676de39991000669475bf4af3d8341d22ab78a8a402c9c9214a2f1212267fL5-R5): Updated the `nitro-contracts` commit hash from `26ce69b21816956bb63c9fce36ed404c12d436a1` to `8e58a9e2612f2819a9060d99ca1fb33de4b1414b` to reflect the latest changes.